### PR TITLE
refactor: use docker volumes rather than filesystem mounts

### DIFF
--- a/.env
+++ b/.env
@@ -39,6 +39,7 @@ PLACE_REST_API_TAG=beta
 PLACE_RUBBER_SOUL_TAG=beta
 # PLACE_TRIGGERS_TAG=beta
 # PLACE_SOURCE_TAG=beta
+# PLACE_NGINX_TAG=latest
 
 # PlaceOS variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ networks:
       - subnet: 172.31.231.0/24
 
 volumes:
+  elastic-data:
+  influx-data:
+  redis-data:
+  rethink-data:
   www:
 
 # YAML Anchors
@@ -127,8 +131,6 @@ services:
       - etcd
       - redis
       - rethink
-    volumes:
-      - ./data/core-drivers:/app/bin/drivers:Z
     environment:
       # Service Hosts
       << : *etcd-client-env
@@ -277,7 +279,9 @@ services:
       placeos:
         ipv4_address: 172.31.231.10
     volumes:
-      - ./data/elastic-data:/usr/share/elasticsearch/data:Z
+      - type: volume
+        source: elastic-data
+        target: /usr/share/elasticsearch/data
     environment:
       bootstrap.memory_lock: "true"
       cluster.routing.allocation.disk.threshold_enabled: "false"
@@ -312,7 +316,9 @@ services:
     healthcheck:
       test: influx bucket list
     volumes:
-      - ./data/influx-data:/root/.influxdbv2
+      - type: volume
+        source: influx-data
+        target: /root/.influxdbv2
     command: "--reporting-disabled"
 
   nginx:
@@ -330,9 +336,6 @@ services:
       - auth
       - api
     volumes:
-      - ./config/nginx/nginx.conf:/nginx.conf:Z
-      - ./config/nginx/bearer.lua:/bearer.lua:Z
-      - ./ssl/:/etc/nginx/ssl/:Z
       - type: volume
         source: www
         target: /etc/nginx/html/
@@ -354,8 +357,9 @@ services:
       placeos:
         ipv4_address: 172.31.231.13
     volumes:
-      - ./data/redis-data:/data:Z
-      - ./config/redis.conf:/usr/local/etc/redis/redis.conf:Z
+      - type: volume
+        source: redis-data
+        target: /data
     environment:
       TZ: $TZ
 
@@ -370,6 +374,8 @@ services:
       placeos:
         ipv4_address: 172.31.231.14
     volumes:
-      - ./data/rethink-data:/data/rethinkdb_data/:Z
+      - type: volume
+        source: rethink-data
+        target: /data/rethinkdb_data
     environment:
       TZ: $TZ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,7 +304,7 @@ services:
       TZ: $TZ
 
   influxdb:
-    image: quay.io/influxdb/influxdb:${INFLUXDB_IMAGE_TAG-2.0.0-beta}
+    image: quay.io/influxdb/influxdb:${INFLUXDB_IMAGE_TAG:-2.0.0-beta}
     container_name: influx
     restart: always
     networks:
@@ -322,7 +322,7 @@ services:
     command: "--reporting-disabled"
 
   nginx:
-    image: ubergarm/openresty-nginx-jwt
+    image: placeos/nginx:${PLACE_NGINX_TAG:-nightly}
     restart: always
     container_name: nginx
     hostname: nginx


### PR DESCRIPTION
Strip filesystem mounts in favour of explicit Docker volumes.
This will not be backwards compatible with existing deployments