### PR TITLE
fix(scripts:run-sam-task): use task binary

### DIFF
--- a/scripts/run-sam-task
+++ b/scripts/run-sam-task
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE_PROJECT_NAME=placeos docker-compose run --rm --no-deps init make sam "$@"
+COMPOSE_PROJECT_NAME=placeos docker-compose run --rm --no-deps init scripts/task "$@"


### PR DESCRIPTION
Tasks in the init container are now compiled, this PR switches from the make strategy to using the task binary