### PR TITLE
Feat/staff api

### DIFF
--- a/.env
+++ b/.env
@@ -39,7 +39,7 @@ PLACE_REST_API_TAG=beta
 PLACE_RUBBER_SOUL_TAG=beta
 # PLACE_TRIGGERS_TAG=beta
 # PLACE_SOURCE_TAG=beta
-# PLACE_NGINX_TAG=latest
+PLACE_NGINX_TAG=staff-api
 
 # PlaceOS variables
 
@@ -54,6 +54,11 @@ PLACE_PASSWORD=development
 PLACE_USERNAME="Place Support (localhost:8443)"
 
 PLACE_SERVER_SECRET=development
+
+# Staff API variables
+
+POSTGRES_USER=placeos
+POSTGRES_PASSWORD=development
 
 # Monitor Node variables
 

--- a/.env
+++ b/.env
@@ -39,6 +39,7 @@ PLACE_REST_API_TAG=beta
 PLACE_RUBBER_SOUL_TAG=beta
 # PLACE_TRIGGERS_TAG=beta
 # PLACE_SOURCE_TAG=beta
+# PLACE_NGINX_TAG=latest
 
 # PlaceOS variables
 

--- a/.env
+++ b/.env
@@ -39,7 +39,6 @@ PLACE_REST_API_TAG=beta
 PLACE_RUBBER_SOUL_TAG=beta
 # PLACE_TRIGGERS_TAG=beta
 # PLACE_SOURCE_TAG=beta
-PLACE_NGINX_TAG=staff-api
 
 # PlaceOS variables
 

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - "placeos.local:nginx"
     env_file:
       - .env.secret_key
+      - .env.public_key
     environment:
       STAFF_TIME_ZONE: $TZ
       PG_DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/placeos"

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -33,11 +33,15 @@ services:
     depends_on:
       - postgres
     external_links:
-      - "placeos.local:nginx"
+      - "nginx:placeos.local"
     env_file:
       - .env.secret_key
       - .env.public_key
     environment:
       STAFF_TIME_ZONE: $TZ
       PG_DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/placeos"
-      PLACE_URI: "http://placeos.local"
+      PLACE_URI: "https://placeos.local"
+      PLACE_EMAIL: ${PLACE_EMAIL:-support@place.tech}
+      PLACE_PASSWORD: ${PLACE_PASSWORD:-development}
+      PLACE_AUTH_CLIENT_ID: "please_copy_and_paste_from_backoffice"
+      PLACE_AUTH_SECRET:    "please_copy_and_paste_from_backoffice"

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.7"
+
+networks:
+  placeos_placeos:
+    external: true
+
+volumes:
+  postgres-data:
+
+services:
+
+  postgres:  # Database used by Staff API
+    image: postgres:${POSTGRES_VERSION:-13-alpine}
+    container_name: postgres
+    restart: unless-stopped
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.17
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      TZ: $TZ
+      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+
+  staff:  # Staff API
+    image: placeos/staff-api:${STAFF_API_VERSION:-latest}
+    container_name: staff
+    restart: unless-stopped
+    networks:
+      placeos:
+        ipv4_address: 172.31.231.18
+    depends_on:
+      - postgres
+    external_links:
+      - "placeos.local:nginx"
+    env_file:
+      - .env.secret_key
+    environment:
+      STAFF_TIME_ZONE: $TZ
+      PG_DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/placeos"
+      PLACE_URI: "http://placeos.local"

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     environment:
       STAFF_TIME_ZONE: $TZ
       PG_DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/placeos"
-      PLACE_URI: "https://placeos.local"
+      PLACE_URI: "http://placeos.local"
       PLACE_EMAIL: ${PLACE_EMAIL:-support@place.tech}
       PLACE_PASSWORD: ${PLACE_PASSWORD:-development}
       PLACE_AUTH_CLIENT_ID: "please_copy_and_paste_from_backoffice"

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -38,10 +38,7 @@ services:
       - .env.secret_key
       - .env.public_key
     environment:
+      SG_ENV: production
       STAFF_TIME_ZONE: $TZ
       PG_DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/placeos"
       PLACE_URI: "http://placeos.local"
-      PLACE_EMAIL: ${PLACE_EMAIL:-support@place.tech}
-      PLACE_PASSWORD: ${PLACE_PASSWORD:-development}
-      PLACE_AUTH_CLIENT_ID: "please_copy_and_paste_from_backoffice"
-      PLACE_AUTH_SECRET:    "please_copy_and_paste_from_backoffice"

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     restart: unless-stopped
     networks:
       placeos:
-        ipv4_address: 172.31.231.17
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -29,7 +28,6 @@ services:
     restart: unless-stopped
     networks:
       placeos:
-        ipv4_address: 172.31.231.18
     depends_on:
       - postgres
     external_links:

--- a/compose-files/staff/docker-compose.yml
+++ b/compose-files/staff/docker-compose.yml
@@ -1,9 +1,5 @@
 version: "3.7"
 
-networks:
-  placeos_placeos:
-    external: true
-
 volumes:
   postgres-data:
 

--- a/install
+++ b/install
@@ -61,6 +61,9 @@ PLACE_DOMAIN=${PLACE_DOMAIN:="localhost:8443"}
 PLACE_EMAIL=${PLACE_EMAIL:="support@place.tech"}
 PLACE_PASSWORD=${PLACE_PASSWORD:="development"}
 
+# staff-api currently requires a slightly different nginx image
+$setup_staff_api == "true" && export PLACE_NGINX_TAG="staff-api"
+
 echo "=== Generating secrets..."
 ./scripts/generate-secrets
 

--- a/install
+++ b/install
@@ -19,6 +19,7 @@ Usage: ./install [options]
 install must be run from the root of the environment.
 
 Options:
+    -a, --staff                      Set up Staff API
     -e, --elk                        Set up ELK stack
     -s, --sentry                     Set up Sentry
 EOF
@@ -28,6 +29,7 @@ SERVICES=('')
 
 setup_elastic_stack=false
 setup_sentry=false
+setup_staff=false
 while [[ $# -gt 0 ]]
 do
   arg="$1"
@@ -40,6 +42,11 @@ do
     -s|--sentry)
     setup_sentry=true
     SERVICES+=('-s')
+    shift
+    ;;
+    -a|--staff)
+    setup_staff_api=true
+    SERVICES+=('-a')
     shift
     ;;
     -h |--help | *)
@@ -84,6 +91,12 @@ sleep 5
 
 echo "=== Running init container"
 ./scripts/run-init-container
+
+if [[ $setup_staff_api == "true" ]]
+then
+    echo "=== Setting up Staff API..."
+    PLACE_DOMAIN=placeos.local ./scripts/run-init-container
+fi
 
 echo -e "\n=== Setup complete. Login to https://$PLACE_DOMAIN/backoffice/ with"
 echo "$PLACE_EMAIL:$PLACE_PASSWORD"

--- a/scripts/start-services
+++ b/scripts/start-services
@@ -16,6 +16,10 @@ do
     COMPOSE_FILES+=('-f ./compose-files/sentry/docker-compose.yml')
     shift
     ;;
+    -a|--staff)
+    COMPOSE_FILES+=('-f ./compose-files/staff/docker-compose.yml')
+    shift
+    ;;
   esac
 done
 


### PR DESCRIPTION
Optionally deploy staff-api (and postgres) services, when `-a` flag is used with `install` script.

This will also create an additional placeos domain "placeos.local" with the sole purpose of allowing `staff` to reach (placeos) `api` container internally - because the default `localhost:8443` location for the placeos api is not reachable from the staff container (`localhost` will route to the current container instead of the host)