### PR TITLE
nginx.conf: use variables instead of upstream directive

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -17,30 +17,10 @@ http {
     '"$http_referer" "$http_user_agent" '
     '$request_time $upstream_response_time';
   access_log /dev/stdout request_upstream;
-  sendfile        on;
-  tcp_nopush     on;
-  gzip  on;
+  sendfile    on;
+  tcp_nopush  on;
+  gzip        on;
 
-  upstream api {
-    server api:3000;
-  }
-
-  upstream auth {
-    server auth:8080;
-  }
-
-  upstream dispatch {
-    server dispatch:8086;
-  }
-
-  upstream influxdb {
-    server influxdb:9999;
-  }
-
-  upstream staff {
-    server staff:8080;
-  }
-  
   server {
     listen 80 default_server;
     server_name _;
@@ -57,6 +37,14 @@ http {
     ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
     ssl_dhparam /etc/nginx/ssl/dhparam.pem;
 
+    resolver 127.0.0.11 valid=10s;
+    set $api      api:3000;
+    set $auth     auth:8080;
+    set $dispatch dispatch:8086;
+    set $staff    staff:8080;
+    set $influx   influx:9999;
+    set $kibana   kibana:5601;
+    
     location ~ /\. {
       deny all;
     }
@@ -67,7 +55,7 @@ http {
     }
 
     location /api/ {
-        proxy_pass  http://api;
+        proxy_pass  http://$api;
         proxy_redirect   off;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
@@ -81,20 +69,20 @@ http {
         proxy_read_timeout 5m;
 
         location /api/server/ {
-          proxy_pass  http://dispatch;
+          proxy_pass  http://$dispatch;
         }
 
         location /api/files/ {
-          proxy_pass  http://auth;
+          proxy_pass  http://$auth;
         }
 
         location /api/staff/ {
-          proxy_pass  http://staff;
+          proxy_pass  http://$staff;
         }
     }
 
     location /auth/ {
-      proxy_pass  http://auth;
+      proxy_pass  http://$auth;
       proxy_redirect   off;
       proxy_http_version 1.1;
       proxy_set_header Host $http_host;
@@ -110,7 +98,7 @@ http {
 
     location /influxdb/ {
       access_by_lua_file  /bearer.lua;
-      proxy_pass  http://influxdb/;
+      proxy_pass  http://$influx/;
 
       set_by_lua $influxdb_token 'return "Token " .. os.getenv("INFLUX_API_KEY")';
       proxy_set_header Authorization $influxdb_token;
@@ -127,8 +115,6 @@ http {
       proxy_read_timeout 2m;
     }
 
-    resolver 127.0.0.11;
-    set $kibana kibana:5601;
     location /monitor/ {
       auth_basic "Login";
       auth_basic_user_file /etc/nginx/.htpasswd-kibana;


### PR DESCRIPTION
* Prevent nginx error on start when an upstream is not available (e.g. influx container is stopped). Previously this would require either running all services (even if only a subset was desired) OR manually editing nginx.conf to remove all references to unneeded upstreams.

* No longer require a manual nginx restart when any upstream is restarted (automatically or manually): Since the removal of static container IPs, nginx would return 502 until it is also restarted (nginx would only resolve upstreams once at startup)  