### PR TITLE
update InfluxDB to v2.0.7

### DIFF
--- a/config/nginx/nginx-nossl.conf
+++ b/config/nginx/nginx-nossl.conf
@@ -39,7 +39,7 @@ http {
   }
 
   upstream influxdb {
-    server influxdb:9999;
+    server influxdb:8086;
   }
 
   server {

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -42,7 +42,7 @@ http {
     set $auth     auth:8080;
     set $dispatch dispatch:8086;
     set $staff    staff:8080;
-    set $influx   influx:9999;
+    set $influx   influx:8086;
     set $kibana   kibana:5601;
     
     location ~ /\. {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,7 +348,7 @@ services:
     << : *logging-env
 
   influxdb:
-    image: quay.io/influxdb/influxdb:${INFLUXDB_IMAGE_TAG:-2.0.0-beta}
+    image: quay.io/influxdb/influxdb:${INFLUXDB_IMAGE_TAG:-v2.0.7}
     container_name: influx
     restart: always
     networks:


### PR DESCRIPTION
https://quay.io/repository/influxdb/influxdb?tab=tags

- Looks like 2.0.0 is out of beta now and 2.0.7 is available
- Also fix nginx routing to influx (now :8086 instead of :9999)