### PR TITLE
Use absolute paths for volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,8 +392,8 @@ services:
         source: www
         target: /etc/nginx/html/
         read_only: true
-      - "./config/nginx/nginx.conf:/etc/nginx/nginx.conf"
-      - "./.htpasswd-kibana:/etc/nginx/.htpasswd-kibana"
+      - ${PWD}/config/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ${PWD}/.htpasswd-kibana:/etc/nginx/.htpasswd-kibana
     env_file:
       - *jwt-public
       - *influxdb-api-key


### PR DESCRIPTION
Prevents creation of local file-named directories when they do not exist when running under windows. This appears to be an rather odd edge-case behaviour of docker, [more details here](https://stackoverflow.com/questions/42248198/how-to-mount-a-single-file-in-a-volume#42260979).

Notably this could cause a `.htpasswd-kibana` _directory_ to be created on the host due to #57.