### PR TITLE
Nightly config

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ SG_ENV=development
 
 # PlaceOS Service Image Tags
 
-PLACEOS_TAG=${PLACEOS_TAG:-placeos-1.2109.0}
+PLACEOS_TAG=nightly
 
 PLACE_AUTH_TAG=${PLACEOS_TAG}
 PLACE_CORE_TAG=${PLACEOS_TAG}

--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ SG_ENV=development
 
 # PlaceOS Service Image Tags
 
-PLACEOS_TAG=nightly
+PLACEOS_TAG=${PLACEOS_TAG:-placeos-1.2109.0}
 
 PLACE_AUTH_TAG=${PLACEOS_TAG}
 PLACE_CORE_TAG=${PLACEOS_TAG}

--- a/placeos
+++ b/placeos
@@ -175,17 +175,23 @@ start_environment() {
     # Load contents of .env
     . "${base_path}/.env"
 
-    # Conditional config for backwards compat
-    if [[ $PLACEOS_TAG < "placeos-1.2108.2" ]]; then
-      PLACE_STAFF_API_TAG="nightly"
-      PLACE_NGINX_TAG="staff-api"
-    fi
-    if [[ $PLACEOS_TAG < "placeos-1.2109.0" ]]; then
-      PLACE_FRONTEND_LOADER_IMAGE="frontends"
-    fi
 
     # Overlay the existing environment
     . "${ext_env}"
+
+    # Conditional config for backwards compat
+    if [[ $PLACEOS_TAG =~ ^placeos-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+
+        if [[ $PLACEOS_TAG < "placeos-1.2108.2" ]]; then
+          PLACE_STAFF_API_TAG="nightly"
+          PLACE_NGINX_TAG="staff-api"
+        fi
+
+        if [[ $PLACEOS_TAG < "placeos-1.2109.0" ]]; then
+          PLACE_FRONTEND_LOADER_IMAGE="frontends"
+        fi
+
+    fi
 
     # Cleanup
     set +o allexport


### PR DESCRIPTION
Fixes an issue where launching via `PLACEOS_TAG=nightly ./placeos start` would load config overlays intended for backwards compatibility.
