### PR TITLE
fix: specify missing environment variable due to regression

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,6 +302,8 @@ services:
       - elastic
       - rethink
     environment:
+      # Must be specified for `>= 1.2108.0, <= 1.2109.1`
+      ES_DISABLE_BULK: "0"
       # Service Hosts
       <<: *rethinkdb-client-env
       <<: *elastic-client-env


### PR DESCRIPTION
Explicitly specifying the `ES_DISABLE_BULK` env is necessary due to a regression

- introduced in [9914e2](https://github.com/PlaceOS/rubber-soul/commit/9914e2f5eb54175d890ed5a29d8c54de036166b4#diff-dc5d3e7c61d783baa6414d43d97fb76bcb1b128776181388953fec5db00bfdd6L49)
- fixed in [5a733d](https://github.com/PlaceOS/rubber-soul/commit/5a733d8a51c805f7e454bcb1289ed055c656d74d#diff-dc5d3e7c61d783baa6414d43d97fb76bcb1b128776181388953fec5db00bfdd6L49)