### PR TITLE
Feat/chronograf: Add Chronograf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -380,6 +380,9 @@ services:
     networks:
       placeos:
     <<: *std-logging
+    env_file:
+      - *influxdb-api-key
+      - .env.chronograf  # Container TOKEN_SECRET for OAuth integration
     environment:
       BASE_PATH: /analytics
       INFLUXDB_URL: $INFLUX_HOST
@@ -392,9 +395,6 @@ services:
       GENERIC_SCOPES: "public"
       GENERIC_NAME: "PlaceOS"
       PUBLIC_URL: "https://${PLACE_DOMAIN}"
-    # env_file:
-    #   - *influxdb-api-key
-    #   - *oauth-analytics
 
 
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -358,7 +358,7 @@ services:
       TZ: $TZ
 
   influxdb:
-    image: influxdb:${INFLUXDB_IMAGE_TAG:-2.0.8-alpine}
+    image: influxdb:${INFLUXDB_IMAGE_TAG:-2.0-alpine}
     container_name: influx
     restart: always
     networks:
@@ -372,6 +372,30 @@ services:
         source: influx-data
         target: /root/.influxdbv2
     command: "--reporting-disabled"
+    
+  chronograf:
+    image: chronograf:1.9
+    container_name: chronograf
+    restart: always
+    networks:
+      placeos:
+    <<: *std-logging
+    environment:
+      BASE_PATH: /analytics
+      INFLUXDB_URL: $INFLUX_HOST
+      INFLUXDB_ORG: $INFLUX_ORG
+      GENERIC_CLIENT_ID: "CREATE_AND_COPY_ANALYTICS_CLIENT_ID_FROM_BACKOFFICE"
+      GENERIC_AUTH_URL: "https://${PLACE_DOMAIN}/auth/oauth/authorize"
+      GENERIC_TOKEN_URL: "https://${PLACE_DOMAIN}/auth/oauth/token"
+      GENERIC_API_URL: "https://${PLACE_DOMAIN}/api/engine/v2/users/current"
+      GENERIC_API_KEY: "email"
+      GENERIC_SCOPES: "public"
+      GENERIC_NAME: "PlaceOS"
+      PUBLIC_URL: "https://${PLACE_DOMAIN}"
+    # env_file:
+    #   - *influxdb-api-key
+    #   - *oauth-analytics
+
 
   nginx:
     image: placeos/nginx:${PLACE_NGINX_TAG:-nightly}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,7 +382,7 @@ services:
     <<: *std-logging
     env_file:
       - *influxdb-api-key
-      - .env.chronograf  # Container TOKEN_SECRET for OAuth integration
+      - .env.chronograf  # Contains TOKEN_SECRET for OAuth integration
     environment:
       BASE_PATH: /analytics
       INFLUXDB_URL: $INFLUX_HOST

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -370,7 +370,7 @@ services:
     volumes:
       - type: volume
         source: influx-data
-        target: /root/.influxdbv2
+        target: /var/lib/influxdb2
     command: "--reporting-disabled"
     
   chronograf:


### PR DESCRIPTION
This adds the Chronograf docker container, v1.9.

Chronograf is unfortunately required because:
- InfluxDBv2 frontend currently does [not support](https://github.com/influxdata/influxdb/issues/15721) a custom base href (e.g. [/influxdb](https://github.com/PlaceOS/nginx/blob/main/config/nginx.conf#L111)). When I tested influxdbv2, it worked fine at / with it's own subdomain, but I could not get it to work under any subdirectory - essential API calls would be made to an incorrect path.
- InfluxDBv2 OSS does not support OAuth, so we won't be able to use it's frontend for production deployments (super sad)

This PR:
- adds the Chrongraf container
- adds env vars that configure the local PlaceOS instance as an OAuth2 provider (but still requies 1 env var `GENERIC_CLIENT_ID` to be manually edited)
- Changes the influxDB image version to 2.0 alpine (so will use latest 2.0.x as opposed to 2.0.8 specifically)
- Maps the local influx volume to the new data path used by the dockerhub influx image (as opposed to the path used by the quay.io image).
- REQUIRES these new features in init: https://github.com/PlaceOS/init/pull/47 in order for installation to succeed
- REQUIRES the nginx.conf upstream change in: https://github.com/PlaceOS/nginx/pull/11 in order for the end user to access chronograf frontend

Note that the CI builds will be expected to fail until the above linked PRs in init and nginx are merged, released and utilised by this branch of partner-environment.