### PR TITLE
feat: add `upgrade` and `update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,34 @@ Arguments:
     -h, --help              Display this message
 ```
 
+### `./placeos update`
+
+```
+Usage: ./placeos update [-h|--help] [VERSION]
+
+Modifies PLACEOS_TAG to the selected PlaceOS platform version.
+If VERSION is omitted, defaults to the most recent stable version.
+
+Arguments:
+    --list                  List the available versions
+    -v, --verbose           Write logs to STDOUT in addition to the log file
+    -h, --help              Display this message
+```
+
+### `./placeos upgrade`
+
+```
+Usage: ./placeos upgrade [-h|--help] [VERSION]
+
+Upgrades the PlaceOS Partner Environment.
+If VERSION is omitted, defaults to the most recent stable version.
+
+Arguments:
+    --list                  Lists versions of the Partner Environment
+    -v, --verbose           Write logs to STDOUT in addition to the log file
+    -h, --help              Display this message
+```
+
 ### `$ ./placeos task`
 
 ```shell-session

--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ These will need to be installed prior to running `./placeos start`:
 ```shell-session
 Usage: ./placeos [-h|--help] [command]
 
-Helper script for interfacing with the PlaceOS Partner Environment
+Helper script for interfacing with the PlaceOS Partner Environment.
 
 Command:
     start                   Start the environment.
     stop                    Stops the environment.
+    update                  Update the platform version.
+    upgrade                 Upgrade the Partner Environment.
+    task                    Runs a task in the environment.
     help                    Display this message.
 ```
 
@@ -67,7 +70,7 @@ Command:
 ```shell-session
 Usage: ./placeos start [-h|--help]
 
-Start the PlaceOS environment
+Start the PlaceOS environment.
 
 Arguments:
     --email EMAIL           Email to setup an admin account for. [default: support@place.tech]
@@ -84,11 +87,39 @@ Arguments:
 ```shell-session
 Usage: ./placeos stop [-h|--help]
 
-Stop the PlaceOS environment
+Stop the PlaceOS environment.
 
 Arguments:
     -v, --verbose           Write logs to STDOUT in addition to the log file.
-    -h, --help              Display this message
+    -h, --help              Display this message.
+```
+
+### `./placeos update`
+
+```
+Usage: ./placeos update [-h|--help] [VERSION]
+
+Modifies PLACEOS_TAG to the selected PlaceOS platform version.
+If VERSION is omitted, defaults to the most recent stable version.
+
+Arguments:
+    --list                  List the available versions.
+    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -h, --help              Display this message.
+```
+
+### `./placeos upgrade`
+
+```
+Usage: ./placeos upgrade [-h|--help] [VERSION]
+
+Upgrades the PlaceOS Partner Environment.
+If VERSION is omitted, defaults to the most recent stable version.
+
+Arguments:
+    --list                  Lists versions of the Partner Environment.
+    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -h, --help              Display this message.
 ```
 
 ### `./placeos update`
@@ -127,8 +158,8 @@ Usage: ./placeos task [-h|--help|help] [-t|--task] <task> [help|...] [arguments.
 Run a task in the PlaceOS environment.
 
 Arguments:
-    -h, --help              Display this message
-    -t, ---tasks            Display list of available tasks
+    -h, --help              Display this message.
+    -t, ---tasks            Display list of available tasks.
 ```
 
 ## Drivers

--- a/README.md
+++ b/README.md
@@ -122,34 +122,6 @@ Arguments:
     -h, --help              Display this message.
 ```
 
-### `./placeos update`
-
-```
-Usage: ./placeos update [-h|--help] [VERSION]
-
-Modifies PLACEOS_TAG to the selected PlaceOS platform version.
-If VERSION is omitted, defaults to the most recent stable version.
-
-Arguments:
-    --list                  List the available versions
-    -v, --verbose           Write logs to STDOUT in addition to the log file
-    -h, --help              Display this message
-```
-
-### `./placeos upgrade`
-
-```
-Usage: ./placeos upgrade [-h|--help] [VERSION]
-
-Upgrades the PlaceOS Partner Environment.
-If VERSION is omitted, defaults to the most recent stable version.
-
-Arguments:
-    --list                  Lists versions of the Partner Environment
-    -v, --verbose           Write logs to STDOUT in addition to the log file
-    -h, --help              Display this message
-```
-
 ### `$ ./placeos task`
 
 ```shell-session

--- a/placeos
+++ b/placeos
@@ -487,7 +487,7 @@ update_environment__usage() (
 Usage: ./placeos update [-h|--help] [VERSION]
 
 Modifies PLACEOS_TAG to the selected PlaceOS platform version.
-If VERSION is unset, defaults to the most recent stable version.
+If VERSION is omitted, defaults to the most recent stable version.
 
 Arguments:
     --list                  List the available versions

--- a/placeos
+++ b/placeos
@@ -89,7 +89,7 @@ unknown_argument() (
 )
 
 prompt() (
-  echo -e "${PROMPT} ${1}"
+    echo -e "${PROMPT} ${1}"
 )
 
 abort() (
@@ -295,10 +295,10 @@ start_environment() (
     fi
 
     if [[ $ENABLE_KIBANA == "true" ]] || [[ $enable_kibana == "true" ]]; then
-      PROFILES+=" --profile kibana"
-      if [[ $(uname) == "Linux" ]]; then
-        PROFILES+=" --profile metricbeat"
-      fi
+        PROFILES+=" --profile kibana"
+        if [[ $(uname) == "Linux" ]]; then
+            PROFILES+=" --profile metricbeat"
+        fi
     fi
 
     run_or_abort \
@@ -423,12 +423,19 @@ task() (
 # Update
 ###################################################################################################
 
+PLACEOS_RELEASE_REPO="PlaceOS/PlaceOS"
+
 CALVER_FULL_REGEX='[0-9]+\.[0-9]{4}\.[0-9]+(-rc[0-9]+)?'
-CALVER_MONTH_REGEX='^[0-9]+\.[0-9]{4}$'
-VERSION_CHANNEL_REGEX='^(nightly|preview|latest)$'
+CALVER_MONTH_REGEX='[0-9]+\.[0-9]{4}'
+VERSION_CHANNEL_REGEX='(nightly|preview|latest)'
 
 fetch_release_tags() (
-  git ls-remote https://github.com/PlaceOS/PlaceOS | cut -f2 | grep '^refs/tags/' | cut -d'/' -f3 | sort --version-sort --reverse
+    git ls-remote https://github.com/${PLACEOS_RELEASE_REPO} |
+        cut -f2 |
+        grep '^refs/tags/' |
+        cut -d'/' -f3 |
+        sort --version-sort --reverse |
+        sed -E "s/($CALVER_FULL_REGEX|$CALVER_MONTH_REGEX)/placeos-\1/g"
 )
 
 # TODO: Change to `release` once the flow has been established
@@ -437,48 +444,46 @@ RELEASE_BRANCH="nightly"
 # If called without a version, fetches latest.
 # Otherwise fetches notes for passed version
 release_notes() (
-  temporary_changelog="$(mktemp -d)/CHANGELOG.md"
+    temporary_changelog="$(mktemp -d)/CHANGELOG.md"
 
-  curl \
-      --silent \
-      --location \
-      --proto-redir -all,https \
-      https://raw.githubusercontent.com/PlaceOS/PlaceOS/${RELEASE_BRANCH}/CHANGELOG.md > $temporary_changelog
+    curl \
+        --silent \
+        --location \
+        --proto-redir -all,https \
+        https://raw.githubusercontent.com/${PLACEOS_RELEASE_REPO}/${RELEASE_BRANCH}/CHANGELOG.md >$temporary_changelog
 
-  if [[ $# = 1 ]]
-  then
-    version_header="$(grep --extended-regexp "^## ${1}$" "$temporary_changelog" | head -1)"
+    if [[ $# = 1 ]]; then
+        version_header="$(grep --extended-regexp "^## ${1}$" "$temporary_changelog" | head -1)"
 
-    # Check version is present in changelog
-    if [[ ! $version_header ]]
-    then
-      echo -e "${PROMPT} ${red}${1} not found in CHANGELOG${reset}"
-      return
+        # Check version is present in changelog
+        if [[ ! $version_header ]]; then
+            prompt "${red}${1} not found in CHANGELOG${reset}"
+            return
+        fi
+
+        # Remove lines before the version header (simplifies range below)
+        working_copy="${temporary_changelog}.bak"
+        cp "${temporary_changelog}" "${working_copy}"
+        sed -n "/^${version_header}$/,\$p" "$working_copy" >$temporary_changelog
+    else
+        # Extract the latest version
+        version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -1)"
     fi
 
-    # Remove lines before the version header (simplifies range below)
-    working_copy="${temporary_changelog}.bak"
-    cp "${temporary_changelog}" "${working_copy}"
-    sed -n "/^${version_header}$/,\$p" "$working_copy" > $temporary_changelog
-  else
-    # Extract the latest version
-    version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -1)"
-  fi
+    previous_version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -2 | tail -1)"
 
-  previous_version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -2 | tail -1)"
+    # Create a URL that directs to the header of the version in the CHANGELOG
+    anchor="$(echo "$version_header" | tr -d "[:blank:]" | tr -d '.#')"
+    changelog_uri="https://github.com/${PLACEOS_RELEASE_REPO}/blob/${RELEASE_BRANCH}/CHANGELOG.md#${anchor}"
 
-  # Create a URL that directs to the header of the version in the CHANGELOG
-  anchor="$(echo "$version_header"| tr -d "[:blank:]" | tr -d '.#')"
-  changelog_uri="https://github.com/PlaceOS/PlaceOS/blob/${RELEASE_BRANCH}/CHANGELOG.md#${anchor}"
-
-  echo ""
-  echo "For the full PlaceOS release notes, see ${changelog_uri}"
-  sed -E "/^$version_header/,/^$previous_version_header$/!d;//d" "$temporary_changelog"
+    echo ""
+    echo "For the full PlaceOS release notes, see ${changelog_uri}"
+    sed -E "/^$version_header/,/^$previous_version_header$/!d;//d" "$temporary_changelog"
 )
 
 update_environment__usage() (
     cat <<EOF
-Usage: ./placeos update [-h|--help] [--environment] [VERSION]
+Usage: ./placeos update [-h|--help] [VERSION]
 
 Modifies PLACEOS_TAG to the selected PlaceOS platform version
 
@@ -496,20 +501,57 @@ update_environment() (
             update_environment__usage
             exit 0
             ;;
-        *)
+        -*)
             unknown_argument "${command}" "update_environment__usage"
+            ;;
+        *)
+            version="$command"
+            [[ ${#} = 0 ]] || abort "Expected a single VERSION argument."
+            break
             ;;
         esac
     done
 
-    # The basic idea is that the script should not need git...
-    # Users will be able to to the next patch, or minor version
-    # Version info can be extracted from the heads of version branches in a file containing the version
-    abort "Not implemented."
+    tags=$(fetch_release_tags)
+
+    if [[ -z "$version" ]]; then
+        prompt "Plese select from the following versions (CTRL-C to quit)"
+        PS3="PlaceOS version: "
+        select version in $tags; do
+            case $version in
+            *)
+                # shellcheck disable=2076
+                if [[ " $tags " =~ " $version " ]]; then
+                    break
+                else
+                    prompt "$REPLY was not recognised."
+                fi
+                ;;
+            esac
+        done
+    fi
+
+    # shellcheck disable=2076
+    if [[ ! " $tags " =~ " $version " ]]; then
+        prompt "Valid versions are...\n\n$(echo $tags | tr ' ' '\n')\n"
+        abort "$version is not a valid version."
+    fi
+
+    echo $version
 )
 
 # Upgrade
 ###################################################################################################
+
+PARTNER_ENV_REPO="place-labs/partner-environment"
+
+fetch_environment_tags() (
+    git ls-remote https://github.com/${PARTNER_ENV_REPO} |
+        cut -f2 |
+        grep -e '^refs/tags/' |
+        cut -d'/' -f3 |
+        sort --version-sort --reverse
+)
 
 upgrade_environment__usage() (
     cat <<EOF
@@ -521,16 +563,6 @@ Arguments:
     -v, --verbose           Write logs to STDOUT in addition to the log file.
     -h, --help              Display this message
 EOF
-)
-
-PARTNER_ENV_REPO="place-labs/partner-environment"
-
-fetch_environment_tags() (
-  git ls-remote https://github.com/${PARTNER_ENV_REPO} \
-    | cut -f2 \
-    | grep -e '^refs/tags/' \
-    | cut -d'/' -f3 \
-    | sort --version-sort --reverse
 )
 
 upgrade_environment() (
@@ -547,7 +579,7 @@ upgrade_environment() (
         -v | --verbose)
             VERBOSE="true"
             ;;
-        -* )
+        -*)
             unknown_argument "${command}" "upgrade_environment__usage"
             ;;
         *)
@@ -560,44 +592,39 @@ upgrade_environment() (
 
     tags="$(fetch_environment_tags) latest"
 
-    if [[ -z "$version" ]]
-    then
+    if [[ -z "$version" ]]; then
         prompt "Plese select from the following versions (CTRL-C to quit)"
         PS3="PlaceOS version: "
-        select version in $tags
-        do
-        case $version in
+        select version in $tags; do
+            case $version in
             latest)
-            break
-            ;;
-            quit)
-            exit 1
-            ;;
-            *)
-            # shellcheck disable=2076
-            if [[ " $tags " =~ " $version " ]]
-            then
                 break
-            else
-                prompt "$REPLY was not recognised."
-            fi
-            ;;
-        esac
+                ;;
+            quit)
+                exit 1
+                ;;
+            *)
+                # shellcheck disable=2076
+                if [[ " $tags " =~ " $version " ]]; then
+                    break
+                else
+                    prompt "$REPLY was not recognised."
+                fi
+                ;;
+            esac
         done
     fi
 
     # shellcheck disable=2076
-    if [[ ! " $tags " =~ " $version " ]]
-    then
+    if [[ ! " $tags " =~ " $version " ]]; then
         prompt "Valid versions are...\n\n$(echo $tags | tr ' ' '\n')\n"
         abort "$version is not a valid version."
     fi
 
-    if [[ $version = "latest" ]]
-    then
-       reference="master"
+    if [[ $version = "latest" ]]; then
+        reference="master"
     else
-       reference="$version"
+        reference="$version"
     fi
 
     # Set git-config values known to fix git errors
@@ -613,16 +640,15 @@ upgrade_environment() (
     last_commit=$(git rev-parse "$reference")
 
     run_or_abort \
-      "git pull --autostash --quiet --rebase origin $reference" \
-      "Upgrading PlaceOS Partner Environment..." \
-      "Failed to upgrade PlaceOS Partner Environment"
+        "git pull --autostash --quiet --rebase origin $reference" \
+        "Upgrading PlaceOS Partner Environment..." \
+        "Failed to upgrade PlaceOS Partner Environment"
 
     # Check if it was really updated or not
-    if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]
-    then
-      prompt "PlaceOS Partner Environment is already at $version"
+    if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
+        prompt "PlaceOS Partner Environment is already at $version"
     else
-      prompt "PlaceOS Partner Environment has been updated to $version"
+        prompt "PlaceOS Partner Environment has been updated to $version"
     fi
 )
 

--- a/placeos
+++ b/placeos
@@ -443,7 +443,7 @@ RELEASE_BRANCH="nightly"
 
 # If called without a version, fetches latest.
 # Otherwise fetches notes for passed version
-release_notes() (
+changelog() (
     temporary_changelog="$(mktemp -d)/CHANGELOG.md"
 
     curl \
@@ -453,21 +453,21 @@ release_notes() (
         https://raw.githubusercontent.com/${PLACEOS_RELEASE_REPO}/${RELEASE_BRANCH}/CHANGELOG.md >$temporary_changelog
 
     if [[ $# = 1 ]]; then
-        version_header="$(grep --extended-regexp "^## ${1}$" "$temporary_changelog" | head -1)"
+        version=$(echo $1 | sed -E 's/placeos-//g')
+        version_header="$(grep --extended-regexp "^## ${version}$" "$temporary_changelog" | head -1)"
 
         # Check version is present in changelog
         if [[ ! $version_header ]]; then
-            prompt "${red}${1} not found in CHANGELOG${reset}"
+            prompt "${red}${version} not found in CHANGELOG${reset}"
             return
         fi
 
         # Remove lines before the version header (simplifies range below)
-        working_copy="${temporary_changelog}.bak"
-        cp "${temporary_changelog}" "${working_copy}"
-        sed -n "/^${version_header}$/,\$p" "$working_copy" >$temporary_changelog
+        sed -i '.bak' -n "/^${version_header}$/,\$p" "$temporary_changelog"
     else
         # Extract the latest version
         version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -1)"
+        version=$(echo "${version_header}" | sed -E 's/^## (.*)$/\1/')
     fi
 
     previous_version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -2 | tail -1)"
@@ -476,6 +476,7 @@ release_notes() (
     anchor="$(echo "$version_header" | tr -d "[:blank:]" | tr -d '.#')"
     changelog_uri="https://github.com/${PLACEOS_RELEASE_REPO}/blob/${RELEASE_BRANCH}/CHANGELOG.md#${anchor}"
 
+    prompt "${green}Changelog for $version${reset}"
     echo ""
     echo "For the full PlaceOS release notes, see ${changelog_uri}"
     sed -E "/^$version_header/,/^$previous_version_header$/!d;//d" "$temporary_changelog"
@@ -485,14 +486,18 @@ update_environment__usage() (
     cat <<EOF
 Usage: ./placeos update [-h|--help] [VERSION]
 
-Modifies PLACEOS_TAG to the selected PlaceOS platform version
+Modifies PLACEOS_TAG to the selected PlaceOS platform version.
+If VERSION is unset, defaults to the most recent stable version.
 
 Arguments:
+    --list                  List the available versions
+    -v, --verbose           Write logs to STDOUT in addition to the log file
     -h, --help              Display this message
 EOF
 )
 
 update_environment() (
+    version=""
     while [ ${#} -gt 0 ]; do
         command="${1}"
         shift
@@ -500,6 +505,13 @@ update_environment() (
         -h | --help | help)
             update_environment__usage
             exit 0
+            ;;
+        --list)
+            fetch_release_tags
+            exit 0
+            ;;
+        -v | --verbose)
+            VERBOSE="true"
             ;;
         -*)
             unknown_argument "${command}" "update_environment__usage"
@@ -515,29 +527,21 @@ update_environment() (
     tags=$(fetch_release_tags)
 
     if [[ -z "$version" ]]; then
-        prompt "Plese select from the following versions (CTRL-C to quit)"
-        PS3="PlaceOS version: "
-        select version in $tags; do
-            case $version in
-            *)
-                # shellcheck disable=2076
-                if [[ " $tags " =~ " $version " ]]; then
-                    break
-                else
-                    prompt "$REPLY was not recognised."
-                fi
-                ;;
-            esac
-        done
+        version=$(echo "$tags" | grep -Ev "$VERSION_CHANNEL_REGEX" | head -1)
     fi
 
     # shellcheck disable=2076
-    if [[ ! " $tags " =~ " $version " ]]; then
-        prompt "Valid versions are...\n\n$(echo $tags | tr ' ' '\n')\n"
-        abort "$version is not a valid version."
+    if [[ -z "$(grep -E "$CALVER_FULL_REGEX|$CALVER_MONTH_REGEX|$VERSION_CHANNEL_REGEX" <<< $version)" ]]; then
+        prompt "Valid versions are...\n\n$tags\n"
+        abort "${version} is not a valid version."
     fi
 
-    echo $version
+    run_or_abort \
+        "sed -i '.bak' -E 's/^PLACEOS_TAG=.*$/PLACEOS_TAG=\${PLACEOS_TAG:-${version}}/g' '.env'" \
+        "Updating to ${version}" \
+        "Failed to update to ${version}"
+
+    changelog ${version}
 )
 
 # Upgrade
@@ -548,7 +552,7 @@ PARTNER_ENV_REPO="place-labs/partner-environment"
 fetch_environment_tags() (
     git ls-remote https://github.com/${PARTNER_ENV_REPO} |
         cut -f2 |
-        grep -e '^refs/tags/' |
+        grep -E '^refs/tags/|HEAD' |
         cut -d'/' -f3 |
         sort --version-sort --reverse
 )
@@ -557,16 +561,19 @@ upgrade_environment__usage() (
     cat <<EOF
 Usage: ./placeos upgrade [-h|--help] [VERSION]
 
-Upgrades the PlaceOS Partner Environment
+Upgrades the PlaceOS Partner Environment.
+If VERSION is omitted, defaults to the latest version.
 
 Arguments:
-    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    --list                  Lists versions of the Partner Environment
+    -v, --verbose           Write logs to STDOUT in addition to the log file
     -h, --help              Display this message
 EOF
 )
 
 upgrade_environment() (
     version=""
+    tags="$(fetch_environment_tags)"
 
     while [ ${#} -gt 0 ]; do
         command="${1}"
@@ -574,6 +581,10 @@ upgrade_environment() (
         case ${command} in
         -h | --help | help)
             upgrade_environment__usage
+            exit 0
+            ;;
+        --list)
+            echo "$tags"
             exit 0
             ;;
         -v | --verbose)
@@ -590,41 +601,10 @@ upgrade_environment() (
         esac
     done
 
-    tags="$(fetch_environment_tags) latest"
-
-    if [[ -z "$version" ]]; then
-        prompt "Plese select from the following versions (CTRL-C to quit)"
-        PS3="PlaceOS version: "
-        select version in $tags; do
-            case $version in
-            latest)
-                break
-                ;;
-            quit)
-                exit 1
-                ;;
-            *)
-                # shellcheck disable=2076
-                if [[ " $tags " =~ " $version " ]]; then
-                    break
-                else
-                    prompt "$REPLY was not recognised."
-                fi
-                ;;
-            esac
-        done
-    fi
-
     # shellcheck disable=2076
     if [[ ! " $tags " =~ " $version " ]]; then
-        prompt "Valid versions are...\n\n$(echo $tags | tr ' ' '\n')\n"
+        prompt "Valid versions are...\n\n$tags\n"
         abort "$version is not a valid version."
-    fi
-
-    if [[ $version = "latest" ]]; then
-        reference="master"
-    else
-        reference="$version"
     fi
 
     # Set git-config values known to fix git errors
@@ -637,10 +617,10 @@ upgrade_environment() (
     git config --local fetch.fsck.zeroPaddedFilemode ignore
     git config --local receive.fsck.zeroPaddedFilemode ignore
 
-    last_commit=$(git rev-parse "$reference")
+    last_commit=$(git rev-parse "$version")
 
     run_or_abort \
-        "git pull --autostash --quiet --rebase origin $reference" \
+        "git pull --autostash --quiet --rebase origin $version" \
         "Upgrading PlaceOS Partner Environment..." \
         "Failed to upgrade PlaceOS Partner Environment"
 
@@ -648,7 +628,7 @@ upgrade_environment() (
     if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
         prompt "PlaceOS Partner Environment is already at $version"
     else
-        prompt "PlaceOS Partner Environment has been updated to $version"
+        prompt "PlaceOS Partner Environment is now at $version"
     fi
 )
 

--- a/placeos
+++ b/placeos
@@ -146,7 +146,7 @@ start_environment__usage() (
     cat <<EOF
 Usage: ./placeos start [-h|--help]
 
-Start the PlaceOS environment
+Start the PlaceOS environment.
 
 Arguments:
     --hard-reset            Reset the environment to a default state.
@@ -341,11 +341,11 @@ stop_environment__usage() (
     cat <<EOF
 Usage: ./placeos stop [-h|--help]
 
-Stop the PlaceOS environment
+Stop the PlaceOS environment.
 
 Arguments:
     -v, --verbose           Write logs to STDOUT in addition to the log file.
-    -h, --help              Display this message
+    -h, --help              Display this message.
 EOF
 )
 
@@ -383,8 +383,8 @@ Usage: ./placeos task [-h|--help|help] [-t|--task] <task> [help|...] [arguments.
 Run a task in the PlaceOS environment.
 
 Arguments:
-    -h, --help              Display this message
-    -t, ---tasks            Display list of available tasks
+    -h, --help              Display this message.
+    -t, ---tasks            Display list of available tasks.
 EOF
 )
 
@@ -490,9 +490,9 @@ Modifies PLACEOS_TAG to the selected PlaceOS platform version.
 If VERSION is omitted, defaults to the most recent stable version.
 
 Arguments:
-    --list                  List the available versions
-    -v, --verbose           Write logs to STDOUT in addition to the log file
-    -h, --help              Display this message
+    --list                  List the available versions.
+    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -h, --help              Display this message.
 EOF
 )
 
@@ -565,9 +565,9 @@ Upgrades the PlaceOS Partner Environment.
 If VERSION is omitted, defaults to the latest version.
 
 Arguments:
-    --list                  Lists versions of the Partner Environment
-    -v, --verbose           Write logs to STDOUT in addition to the log file
-    -h, --help              Display this message
+    --list                  Lists versions of the Partner Environment.
+    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -h, --help              Display this message.
 EOF
 )
 
@@ -639,7 +639,7 @@ usage() (
     cat <<EOF
 Usage: ./placeos [-h|--help] [command]
 
-Helper script for interfacing with the PlaceOS Partner Environment
+Helper script for interfacing with the PlaceOS Partner Environment.
 
 Command:
     start                   Start the environment.

--- a/placeos
+++ b/placeos
@@ -83,7 +83,7 @@ PROMPT="░░░"
 unknown_argument() (
     unknown_arg="${1}"
     usage="${2}"
-    [ -n "${unknown_arg}" ] && echo -e "${PROMPT} ${red}Unknown option:${reset} ${unknown_arg}"
+    [ -n "${unknown_arg}" ] && prompt "${red}Unknown option:${reset} ${unknown_arg}"
     eval "${usage}"
     exit 1
 )
@@ -93,7 +93,7 @@ prompt() (
 )
 
 abort() (
-    echo -e "${PROMPT} ${red}${1}${reset}"
+    prompt "${red}${1}${reset}"
     prompt "Logs can be found in ${logfile}"
     exit 1
 )

--- a/placeos
+++ b/placeos
@@ -89,7 +89,7 @@ unknown_argument() (
 )
 
 prompt() (
-  echo "${PROMPT} ${1}"
+  echo -e "${PROMPT} ${1}"
 )
 
 abort() (
@@ -587,7 +587,11 @@ upgrade_environment() (
     fi
 
     # shellcheck disable=2076
-    [[ " $tags " =~ " $version " ]] || abort "$version is not a valid version."
+    if [[ ! " $tags " =~ " $version " ]]
+    then
+        prompt "Valid versions are...\n\n$(echo $tags | tr ' ' '\n')\n"
+        abort "$version is not a valid version."
+    fi
 
     if [[ $version = "latest" ]]
     then
@@ -606,47 +610,20 @@ upgrade_environment() (
     git config --local fetch.fsck.zeroPaddedFilemode ignore
     git config --local receive.fsck.zeroPaddedFilemode ignore
 
-    # Autostash on rebase
-    git config --local rebase.autoStash true
-
-    local ret=0
-
-    # Repository state
-    last_head=$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)
-
-    # Checkout update reference
-    run_or_abort \
-        "git checkout -q $reference -- " \
-        "Checking out $version..." \
-        "Failed to checkout $version"
-
-    # branch commit before update (used in changelog)
     last_commit=$(git rev-parse "$reference")
 
     run_or_abort \
-      "git pull --quiet --rebase $reference" \
-      "Upgrade PlaceOS Partner Environment" \
+      "git pull --autostash --quiet --rebase origin $reference" \
+      "Upgrading PlaceOS Partner Environment..." \
       "Failed to upgrade PlaceOS Partner Environment"
 
     # Check if it was really updated or not
     if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]
     then
-      prompt "PlaceOS Partner Environment is already at $version."
+      prompt "PlaceOS Partner Environment is already at $version"
     else
-      prompt "PlaceOS Partner Environment has been updated to $version."
+      prompt "PlaceOS Partner Environment has been updated to $version"
     fi
-
-    # Go back to HEAD previous to update
-    git checkout -q "$last_head" --
-
-    # Unset git-config values set just for the upgrade
-    case "$resetAutoStash" in
-      "") git config --local --unset rebase.autoStash ;;
-      *) git config --local rebase.autoStash "$resetAutoStash" ;;
-    esac
-
-    # Exit with `1` if the update failed
-    exit $ret
 )
 
 # Root Command

--- a/placeos
+++ b/placeos
@@ -78,17 +78,23 @@ COMPOSE_PROJECT_NAME=placeos
 # Helpers
 ###################################################################################################
 
+PROMPT="░░░"
+
 unknown_argument() (
     unknown_arg="${1}"
     usage="${2}"
-    [ -n "${unknown_arg}" ] && echo -e "░░░ ${red}Unknown option:${reset} ${unknown_arg}"
+    [ -n "${unknown_arg}" ] && echo -e "${PROMPT} ${red}Unknown option:${reset} ${unknown_arg}"
     eval "${usage}"
     exit 1
 )
 
+prompt() (
+  echo "${PROMPT} ${1}"
+)
+
 abort() (
-    echo -e "░░░ ${red}${1}${reset}"
-    echo "░░░ Logs can be found in ${logfile}"
+    echo -e "${PROMPT} ${red}${1}${reset}"
+    prompt "Logs can be found in ${logfile}"
     exit 1
 )
 
@@ -100,11 +106,11 @@ run_or_abort() {
 
     exit_code=0
     if [ "${VERBOSE}" == "false" ]; then
-        start_spinner "░░░ ${start}"
+        start_spinner "${PROMPT} ${start}"
         eval "${task} >>${logfile} 2>&1" || exit_code=$?
         stop_spinner $exit_code
     else
-        echo "░░░ ${start}"
+        prompt "${start}"
         eval "${task} 2>&1 | tee -a ${logfile}" || exit_code=$?
     fi
 
@@ -169,7 +175,7 @@ start_environment() (
         shift
         case ${command} in
         --hard-reset)
-            read -rp "░░░ $(echo -e "${red}Warning:${reset}") This will reset your environment. Would you like to continue (y/n)? " choice
+            read -rp "${PROMPT} $(echo -e "${red}Warning:${reset}") This will reset your environment. Would you like to continue (y/n)? " choice
             case "${choice}" in
             y | Y | YES | yes)
                 hard_reset=true
@@ -218,9 +224,9 @@ start_environment() (
 
     load_environment
 
-    echo "░░░ Starting PlaceOS <${PLACEOS_TAG}>"
+    prompt "Starting PlaceOS <${PLACEOS_TAG}>"
 
-    [ $VERBOSE == "false" ] && echo "░░░ For detailed logging, run \`tail -f ${logfile}\`"
+    [ $VERBOSE == "false" ] && prompt "For detailed logging, run \`tail -f ${logfile}\`"
 
     EMAIL_ENV="${base_path}/.env.email"
 
@@ -258,7 +264,7 @@ start_environment() (
         PLACE_EMAIL=${PLACE_EMAIL:-"$(git config user.email 2>/dev/null || exit 0)"}
         PLACE_EMAIL=${PLACE_EMAIL:-"support@place.tech"}
 
-        read -rp "░░░ Please enter an email ($(echo -e "${green}default:${reset}") ${PLACE_EMAIL}): " choice
+        read -rp "${PROMPT} Please enter an email ($(echo -e "${green}default:${reset}") ${PLACE_EMAIL}): " choice
         if [ -n "${choice}" ]; then
             PLACE_EMAIL=${choice}
         fi
@@ -268,7 +274,7 @@ start_environment() (
     # TODO: Check for the user before asking for a password
     # TODO: Autogenerate the default password
     while [ -z ${PLACE_PASSWORD+x} ]; do
-        read -srp "░░░ Please enter a password: " choice
+        read -srp "${PROMPT} Please enter a password: " choice
         PLACE_PASSWORD="${choice}"
         # Newline after response
         echo ""
@@ -284,7 +290,7 @@ start_environment() (
     fi
 
     if [[ -d "${base_path}/.htpasswd-kibana" ]]; then
-        echo "░░░ Detected malformed auth file. Cleaning up"
+        prompt "Detected malformed auth file. Cleaning up"
         rm -r "${base_path}/.htpasswd-kibana"
     fi
 
@@ -324,8 +330,8 @@ start_environment() (
         "Initialising PlaceOS with default domain ($PLACE_DOMAIN)..." \
         "Failed to create user entity."
 
-    echo "░░░ PlaceOS initialised. Login to https://$PLACE_DOMAIN/backoffice/ with..."
-    echo "░░░ $PLACE_EMAIL:$PLACE_PASSWORD"
+    prompt "PlaceOS initialised. Login to https://$PLACE_DOMAIN/backoffice/ with..."
+    prompt "$PLACE_EMAIL:$PLACE_PASSWORD"
 )
 
 # Stop
@@ -417,11 +423,64 @@ task() (
 # Update
 ###################################################################################################
 
+CALVER_FULL_REGEX='[0-9]+\.[0-9]{4}\.[0-9]+(-rc[0-9]+)?'
+CALVER_MONTH_REGEX='^[0-9]+\.[0-9]{4}$'
+VERSION_CHANNEL_REGEX='^(nightly|preview|latest)$'
+
+fetch_release_tags() (
+  git ls-remote https://github.com/PlaceOS/PlaceOS | cut -f2 | grep '^refs/tags/' | cut -d'/' -f3 | sort --version-sort --reverse
+)
+
+# TODO: Change to `release` once the flow has been established
+RELEASE_BRANCH="nightly"
+
+# If called without a version, fetches latest.
+# Otherwise fetches notes for passed version
+release_notes() (
+  temporary_changelog="$(mktemp -d)/CHANGELOG.md"
+
+  curl \
+      --silent \
+      --location \
+      --proto-redir -all,https \
+      https://raw.githubusercontent.com/PlaceOS/PlaceOS/${RELEASE_BRANCH}/CHANGELOG.md > $temporary_changelog
+
+  if [[ $# = 1 ]]
+  then
+    version_header="$(grep --extended-regexp "^## ${1}$" "$temporary_changelog" | head -1)"
+
+    # Check version is present in changelog
+    if [[ ! $version_header ]]
+    then
+      echo -e "${PROMPT} ${red}${1} not found in CHANGELOG${reset}"
+      return
+    fi
+
+    # Remove lines before the version header (simplifies range below)
+    working_copy="${temporary_changelog}.bak"
+    cp "${temporary_changelog}" "${working_copy}"
+    sed -n "/^${version_header}$/,\$p" "$working_copy" > $temporary_changelog
+  else
+    # Extract the latest version
+    version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -1)"
+  fi
+
+  previous_version_header="$(grep --extended-regexp "^## ${CALVER_FULL_REGEX}$" "$temporary_changelog" | head -2 | tail -1)"
+
+  # Create a URL that directs to the header of the version in the CHANGELOG
+  anchor="$(echo "$version_header"| tr -d "[:blank:]" | tr -d '.#')"
+  changelog_uri="https://github.com/PlaceOS/PlaceOS/blob/${RELEASE_BRANCH}/CHANGELOG.md#${anchor}"
+
+  echo ""
+  echo "For the full PlaceOS release notes, see ${changelog_uri}"
+  sed -E "/^$version_header/,/^$previous_version_header$/!d;//d" "$temporary_changelog"
+)
+
 update_environment__usage() (
     cat <<EOF
-Usage: ./placeos update [-h|--help]
+Usage: ./placeos update [-h|--help] [--environment] [VERSION]
 
-Update the PlaceOS environment
+Modifies PLACEOS_TAG to the selected PlaceOS platform version
 
 Arguments:
     -h, --help              Display this message
@@ -449,6 +508,147 @@ update_environment() (
     abort "Not implemented."
 )
 
+# Upgrade
+###################################################################################################
+
+upgrade_environment__usage() (
+    cat <<EOF
+Usage: ./placeos upgrade [-h|--help] [VERSION]
+
+Upgrades the PlaceOS Partner Environment
+
+Arguments:
+    -v, --verbose           Write logs to STDOUT in addition to the log file.
+    -h, --help              Display this message
+EOF
+)
+
+PARTNER_ENV_REPO="place-labs/partner-environment"
+
+fetch_environment_tags() (
+  git ls-remote https://github.com/${PARTNER_ENV_REPO} \
+    | cut -f2 \
+    | grep -e '^refs/tags/' \
+    | cut -d'/' -f3 \
+    | sort --version-sort --reverse
+)
+
+upgrade_environment() (
+    version=""
+
+    while [ ${#} -gt 0 ]; do
+        command="${1}"
+        shift
+        case ${command} in
+        -h | --help | help)
+            upgrade_environment__usage
+            exit 0
+            ;;
+        -v | --verbose)
+            VERBOSE="true"
+            ;;
+        -* )
+            unknown_argument "${command}" "upgrade_environment__usage"
+            ;;
+        *)
+            version="$command"
+            [[ ${#} = 0 ]] || abort "Expected a single VERSION argument."
+            break
+            ;;
+        esac
+    done
+
+    tags="$(fetch_environment_tags) latest"
+
+    if [[ -z "$version" ]]
+    then
+        prompt "Plese select from the following versions (CTRL-C to quit)"
+        PS3="PlaceOS version: "
+        select version in $tags
+        do
+        case $version in
+            latest)
+            break
+            ;;
+            quit)
+            exit 1
+            ;;
+            *)
+            # shellcheck disable=2076
+            if [[ " $tags " =~ " $version " ]]
+            then
+                break
+            else
+                prompt "$REPLY was not recognised."
+            fi
+            ;;
+        esac
+        done
+    fi
+
+    # shellcheck disable=2076
+    [[ " $tags " =~ " $version " ]] || abort "$version is not a valid version."
+
+    if [[ $version = "latest" ]]
+    then
+       reference="master"
+    else
+       reference="$version"
+    fi
+
+    # Set git-config values known to fix git errors
+    # Line endings
+    git config --local core.eol lf
+    git config --local core.autocrlf false
+
+    # zeroPaddedFilemode fsck errors
+    git config --local fsck.zeroPaddedFilemode ignore
+    git config --local fetch.fsck.zeroPaddedFilemode ignore
+    git config --local receive.fsck.zeroPaddedFilemode ignore
+
+    # Autostash on rebase
+    git config --local rebase.autoStash true
+
+    local ret=0
+
+    # Repository state
+    last_head=$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)
+
+    # Checkout update reference
+    run_or_abort \
+        "git checkout -q $reference -- " \
+        "Checking out $version..." \
+        "Failed to checkout $version"
+
+    # branch commit before update (used in changelog)
+    last_commit=$(git rev-parse "$reference")
+
+    run_or_abort \
+      "git pull --quiet --rebase $reference" \
+      "Upgrade PlaceOS Partner Environment" \
+      "Failed to upgrade PlaceOS Partner Environment"
+
+    # Check if it was really updated or not
+    if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]
+    then
+      prompt "PlaceOS Partner Environment is already at $version."
+    else
+      prompt "PlaceOS Partner Environment has been updated to $version."
+    fi
+
+    # Go back to HEAD previous to update
+    git checkout -q "$last_head" --
+
+    # Unset git-config values set just for the upgrade
+    case "$resetAutoStash" in
+      "") git config --local --unset rebase.autoStash ;;
+      *) git config --local rebase.autoStash "$resetAutoStash" ;;
+    esac
+
+    # Exit with `1` if the update failed
+    exit $ret
+)
+
 # Root Command
 ###################################################################################################
 
@@ -461,6 +661,8 @@ Helper script for interfacing with the PlaceOS Partner Environment
 Command:
     start                   Start the environment.
     stop                    Stops the environment.
+    update                  Update the platform version.
+    upgrade                 Upgrade the Partner Environment.
     task                    Runs a task in the environment.
     help                    Display this message.
 
@@ -483,11 +685,14 @@ start)
 stop)
     stop_environment "$@"
     ;;
-task)
-    task "$@"
-    ;;
 update)
     update_environment "$@"
+    ;;
+upgrade)
+    upgrade_environment "$@"
+    ;;
+task)
+    task "$@"
     ;;
 -h | --help | help)
     usage

--- a/placeos
+++ b/placeos
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=1003,1090
 
 banner() (
     echo
@@ -114,7 +115,7 @@ run_or_abort() {
         eval "${task} 2>&1 | tee -a ${logfile}" || exit_code=$?
     fi
 
-    if [ $ignore_failure != "true" ]; then
+    if [ "$ignore_failure" != "true" ]; then
         [ $exit_code -eq 0 ] || abort "${failure:-"${task} failed with ${exit_code}"}"
     fi
 }
@@ -232,12 +233,12 @@ start_environment() (
 
     set -a
     if [ -f "${EMAIL_ENV}" ]; then
-        . ${EMAIL_ENV}
+        . "${EMAIL_ENV}"
     elif [ -n "${email_argument}" ]; then
         # Override env with CLI arguments
         PLACE_EMAIL=${email_argument}
         # Write the email so as to not prompt the user again.
-        echo "PLACE_EMAIL=${PLACE_EMAIL}" >${EMAIL_ENV}
+        echo "PLACE_EMAIL=${PLACE_EMAIL}" >"${EMAIL_ENV}"
     fi
     set +a
 
@@ -450,10 +451,10 @@ changelog() (
         --silent \
         --location \
         --proto-redir -all,https \
-        https://raw.githubusercontent.com/${PLACEOS_RELEASE_REPO}/${RELEASE_BRANCH}/CHANGELOG.md >$temporary_changelog
+        "https://raw.githubusercontent.com/${PLACEOS_RELEASE_REPO}/${RELEASE_BRANCH}/CHANGELOG.md" >"$temporary_changelog"
 
     if [[ $# = 1 ]]; then
-        version=$(echo $1 | sed -E 's/placeos-//g')
+        version=$(sed -E 's/placeos-//g' <<<"$1")
         version_header="$(grep --extended-regexp "^## ${version}$" "$temporary_changelog" | head -1)"
 
         # Check version is present in changelog


### PR DESCRIPTION
Closes #71

## `./placeos update`

```
Usage: ./placeos update [-h|--help] [VERSION]

Modifies PLACEOS_TAG to the selected PlaceOS platform version.
If VERSION is omitted, defaults to the most recent stable version.

Arguments:
    --list                  List the available versions
    -v, --verbose           Write logs to STDOUT in addition to the log file
    -h, --help              Display this message
```

## `./placeos upgrade`

```
Usage: ./placeos upgrade [-h|--help] [VERSION]

Upgrades the PlaceOS Partner Environment.
If VERSION is omitted, defaults to the most recent stable version.

Arguments:
    --list                  Lists versions of the Partner Environment
    -v, --verbose           Write logs to STDOUT in addition to the log file
    -h, --help              Display this message
```

