### PR TITLE
ci: autoupdates ENV, auto-tags on merge

### DIFF
--- a/.github/workflows/tag-on-update.yml
+++ b/.github/workflows/tag-on-update.yml
@@ -1,0 +1,25 @@
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  tag:
+    name: Tag new release
+    if: ${{ github.event.pull_request.merged && startsWith(github.event.pull_request.title, 'release/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure git user
+        run: |
+          git config user.email "robots@place.technology"
+          git config user.name "PlaceOS Robot"
+
+      - name: Tag the latest release
+        run: |
+          source .env
+          git tag "${PLACEOS_TAG}"
+          git push --tags

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,69 @@
+name: Update to latest release
+
+on:
+  repository_dispatch:
+    types: [update]
+
+env:
+  VERSION_REGEX: '^[0-9]+\.[0-9]{4}\.[0-9]+$'
+
+jobs:
+  latest:
+    name: Get latest PlaceOS version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.latest.outputs.version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      inputs:
+        fetch-depth: 0
+        repository: PlaceOS/PlaceOS
+    - name: Get latest version from PlaceOS/PlaceOS
+      id: version
+      run: |
+        latest=$(git tag | grep -r '${{ env.VERSION_REGEX }}' | sort | tail -1)
+        echo ::set-output name=version::$latest
+
+  update:
+    name: Update
+    needs: latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure git user
+      run: |
+        git config user.email "robots@place.technology"
+        git config user.name "PlaceOS Robot"
+
+    - name: Update files
+      run: |
+        branch='release/${{ needs.latest.outputs.version }}'
+
+        # Switch branch to release/${{ needs.latest.outputs.version }}
+        git checkout "$branch"
+
+        # Update `.env`
+        sed -i -r 's/^PLACEOS_TAG=placeos-${{ env.VERSION_REGEX }}$/PLACEOS_TAG=placeos-${{ needs.placeos-latest.outputs.version }}/g' \
+          .env
+
+        # Update CI matrix
+        sed -i -r 's/${{ env.VERSION_REGEX }}/${{ needs.latest.outputs.version }}/g' \
+          .github/workflows/ci.yml
+
+        # Commit
+        git commit --message='build: update to ${{ needs.latest.outputs.version }}' \
+          .env \
+          .github/workflows/ci.yml
+
+        # Create PR
+        gh pr create \
+          --fill \
+          --head "$branch" \
+          --label 'type: maintenance' \
+          --base master \
+          --body 'See the details for `placeos-${{ steps.get-latest.outputs.version }}`[here](https://github.com/PlaceOS/PlaceOS/releases/tag/${{ needs.latest.outputs.version }}).'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Get latest version from PlaceOS/PlaceOS
       id: version
       run: |
-        latest=$(git tag | grep -r '${{ env.VERSION_REGEX }}' | sort | tail -1)
+        latest=$(git tag --list | grep --extended-regexp '${{ env.VERSION_REGEX }}' | sort | tail -1)
         echo ::set-output name=version::$latest
 
   update:
@@ -46,11 +46,11 @@ jobs:
         git checkout "$branch"
 
         # Update `.env`
-        sed -i -r 's/^PLACEOS_TAG=placeos-${{ env.VERSION_REGEX }}$/PLACEOS_TAG=placeos-${{ needs.placeos-latest.outputs.version }}/g' \
+        sed -i '.bak' -E 's/^PLACEOS_TAG=.*/PLACEOS_TAG=${PLACEOS_TAG:-placeos-${{ needs.placeos-latest.outputs.version }}}/g' \
           .env
 
         # Update CI matrix
-        sed -i -r 's/${{ env.VERSION_REGEX }}/${{ needs.latest.outputs.version }}/g' \
+        sed -i '.bak' -E 's/${{ env.VERSION_REGEX }}/${{ needs.latest.outputs.version }}/g' \
           .github/workflows/ci.yml
 
         # Commit


### PR DESCRIPTION
This makes the partner-environment track PlaceOS/PlaceOS versions.

Updating `.env` by the user will be done in a different script (see #103)